### PR TITLE
Add possibility to connect to a non internet connected bridge

### DIFF
--- a/snipshue/hue_setup.py
+++ b/snipshue/hue_setup.py
@@ -12,8 +12,10 @@ class HueSetup:
 
     bridge_url = None
 
-    def __init__(self):
-        bridge_ip = self._get_bridge_ip()
+    def __init__(self, bridge_ip=None):
+        if bridge_ip is None:
+            bridge_ip = self._get_bridge_ip()
+
         username = self._get_cached_username(bridge_ip)
 
         print "Cached username: " + str(username)

--- a/snipshue/snipshue.py
+++ b/snipshue/snipshue.py
@@ -21,7 +21,7 @@ class SnipsHue:
         :param light_ids: Philips Hue light ids
         """
         if hostname is None or username is None:
-            setup = HueSetup()
+            setup = HueSetup(hostname)
             print(setup.bridge_url)
             url = setup.bridge_url
 


### PR DESCRIPTION
This add a new optional parameter to HueSetup to specify an bridge IP
This is usefull if the bridge has no intenet connection and thus can't
register itself with hue upnp api